### PR TITLE
Remove dot from the default container class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ text               | Value for progress bar's text. Default `null`.
 options            | Options for path drawing. See [progressbar.js documentation](https://github.com/kimmobrunfeldt/progressbar.js#shapecontainer-options).
 initialAnimate     | If `true`, progress bar is animated to given progress when mounted. Default `false`.
 containerStyle     | Styles for progress bar container. Default `{}`.
-containerClassName | Class name for progress bar container. Default `.progressbar-container`.
+containerClassName | Class name for progress bar container. Default `progressbar-container`.
 
 ## Contributing
 

--- a/dist/react-progressbar.js
+++ b/dist/react-progressbar.js
@@ -38,7 +38,7 @@
                 text: null,
                 initialAnimate: false,
                 containerStyle: {},
-                containerClassName: '.progressbar-container'
+                containerClassName: 'progressbar-container'
             };
         },
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ var Shape = React.createClass({
             text: null,
             initialAnimate: false,
             containerStyle: {},
-            containerClassName: '.progressbar-container'
+            containerClassName: 'progressbar-container'
         };
     },
 


### PR DESCRIPTION
The current container class name it's set as `.progressbar-container` (with a dot), which can be a little bit confusing writing the needed CSS ([example](https://codepen.io/sebacruz/pen/XeOoEe)).

This PR remove the point to in order to make it simpler.