### PR TITLE
Typofix: make animation.gif to render in GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # react-progressbar.js
 
 <br>
+
 ![Demo animation](docs/animation.gif)
 
 <br>


### PR DESCRIPTION
because there is no newline after the image, GitHub won't render the `animation.gif` on the repository landing page.

This hugely complex PR will address & eliminate this issue.

You all are welcome.